### PR TITLE
Added Tiddlyserver.app

### DIFF
--- a/Tiddlyserver.app/Contents/MacOS/Tiddlyserver
+++ b/Tiddlyserver.app/Contents/MacOS/Tiddlyserver
@@ -1,0 +1,6 @@
+#!/bin/bash
+read -d '' EXECUTE <<DACODE
+cd $(dirname "$0")/../../..
+node server
+DACODE
+osascript -e "tell application \"Terminal\" to do script \"$EXECUTE\""


### PR DESCRIPTION
This adds an app launcher for mac users. Would like to help you get as close to a 'one click' install as possible. I am writing a short tutorial on tiddlyserver.

I used a script I found here: https://github.com/labor4/ya-appify/blob/master/appify after reading discussion here https://mathiasbynens.be/notes/shell-script-mac-apps to make a simple shell script into a simple app. The .app is just a folder and all it contains is a single script file. The other bits tell it to open the process in a terminal window. The name of the script file needs to be the same as the name of the .app file. This 'app' will always just try to start a node server in the directory it's in (it doesn't know anything about the app). It should also be possible to stuff all of Tiddlyserver inside the app container, if that's ever desirable.