### PR TITLE
Add shebang at the top of server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 //@ts-check
 require("./lib/source-map-support-lib");
 const fs = require('fs');


### PR DESCRIPTION
This is allows `server.js` to be run as the `tiddlyserver` command instead of using `node server.js` :)